### PR TITLE
Add IronIO logging support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 A microservice which acts as a logdrain and forwards messages to HSDP Foundation logging. Supports the new HSDP v2 single tenant solution.
 
 # Features
+- Cloud foundry logdrain endpoint
+- IronIO project logging endpoint 
 - Supports v2 of the HSDP logging API
 - Batch uploads messages (max 25) for good performance
 - Very lean (64MB RAM)

--- a/handlers/ironio.go
+++ b/handlers/ironio.go
@@ -1,0 +1,73 @@
+package handlers
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/influxdata/go-syslog/v2/rfc5424"
+	"github.com/labstack/echo"
+	"github.com/loafoe/go-rabbitmq"
+	"github.com/streadway/amqp"
+)
+
+type IronIOHandler struct {
+	producer rabbitmq.Producer
+	debug    bool
+	token    string
+}
+
+func NewIronIOHandler(token string, producer rabbitmq.Producer) (*IronIOHandler, error) {
+	if token == "" {
+		return nil, fmt.Errorf("Missing TOKEN value")
+	}
+	handler := &IronIOHandler{}
+	handler.token = token
+	handler.producer = producer
+
+	if os.Getenv("DEBUG") == "true" {
+		handler.debug = true
+	}
+	return handler, nil
+}
+
+func ironToRFC5424(now time.Time, ironString string) string {
+	msg := &rfc5424.SyslogMessage{}
+
+	msg.SetPriority(14)
+	msg.SetVersion(1)
+	msg.SetTimestamp(now.Format(time.RFC3339))
+	msg.SetMessage(ironString) // Naive first, we will parse it later
+
+	out, _ := msg.String()
+	return out
+}
+
+func (h *IronIOHandler) Handler() echo.HandlerFunc {
+	return func(c echo.Context) error {
+		t := c.Param("token")
+		if h.token != t {
+			return c.String(http.StatusUnauthorized, "")
+		}
+		b, _ := ioutil.ReadAll(c.Request().Body)
+		go h.push([]byte(ironToRFC5424(time.Now(), string(b))))
+		return c.String(http.StatusOK, "")
+	}
+}
+
+func (h *IronIOHandler) push(raw []byte) {
+	err := h.producer.Publish(Exchange, RoutingKey, amqp.Publishing{
+		Headers:         amqp.Table{},
+		ContentType:     "application/octet-stream",
+		ContentEncoding: "",
+		Body:            raw,
+		DeliveryMode:    amqp.Transient, // 1=non-persistent, 2=persistent
+		Priority:        0,              // 0-9
+		// a bunch of application/implementation-specific fields
+	})
+	if err != nil {
+		fmt.Printf("Error publishing: %v\n", err)
+	}
+}

--- a/handlers/ironio_test.go
+++ b/handlers/ironio_test.go
@@ -1,9 +1,13 @@
 package handlers
 
 import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/labstack/echo"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -14,4 +18,17 @@ func TestIronToRFC5424(t *testing.T) {
 	rfc := ironToRFC5424(now, testPayload)
 
 	assert.Equal(t, "<14>1 2014-07-16T22:55:46+02:00 - - - - - severity=INFO, task_id: 5e299d0af210cc00097e9883, code_name: loafoe/iron-test, project_id: 5e20da41d748ad000ace7654 -- This is a message", rfc)
+}
+
+func TestIronIOHandler(t *testing.T) {
+	e, teardown := setup(t)
+	defer teardown()
+
+	body := bytes.NewBufferString("severity=INFO, task_id: 5e299d0af210cc00097e9883, code_name: loafoe/iron-test, project_id: 5e20da41d748ad000ace7654 -- This is a message")
+
+	req := httptest.NewRequest(echo.POST, "/ironio/drain/t0ken", body)
+	rec := httptest.NewRecorder()
+
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
 }

--- a/handlers/ironio_test.go
+++ b/handlers/ironio_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
@@ -31,4 +32,17 @@ func TestIronIOHandler(t *testing.T) {
 
 	e.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestIronInvalidToken(t *testing.T) {
+	os.Setenv("DEBUG", "true")
+
+	e, teardown := setup(t)
+	defer teardown()
+
+	req := httptest.NewRequest(echo.POST, "/ironio/drain/t00ken", nil)
+	rec := httptest.NewRecorder()
+
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
 }

--- a/handlers/ironio_test.go
+++ b/handlers/ironio_test.go
@@ -1,0 +1,17 @@
+package handlers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIronToRFC5424(t *testing.T) {
+	testPayload := "severity=INFO, task_id: 5e299d0af210cc00097e9883, code_name: loafoe/iron-test, project_id: 5e20da41d748ad000ace7654 -- This is a message"
+	now := time.Unix(1405544146, 0)
+
+	rfc := ironToRFC5424(now, testPayload)
+
+	assert.Equal(t, "<14>1 2014-07-16T22:55:46+02:00 - - - - - severity=INFO, task_id: 5e299d0af210cc00097e9883, code_name: loafoe/iron-test, project_id: 5e20da41d748ad000ace7654 -- This is a message", rfc)
+}

--- a/main.go
+++ b/main.go
@@ -47,7 +47,7 @@ func main() {
 	// IronIO
 	ironIOHandler, err := handlers.NewIronIOHandler(os.Getenv("TOKEN"), producer)
 	if err != nil {
-		logger.Errorf("Failed to setup SyslogHandler: %s", err)
+		logger.Errorf("Failed to setup IronIOHandler: %s", err)
 		os.Exit(1)
 	}
 

--- a/main.go
+++ b/main.go
@@ -44,12 +44,20 @@ func main() {
 		os.Exit(1)
 	}
 
+	// IronIO
+	ironIOHandler, err := handlers.NewIronIOHandler(os.Getenv("TOKEN"), producer)
+	if err != nil {
+		logger.Errorf("Failed to setup SyslogHandler: %s", err)
+		os.Exit(1)
+	}
+
 	// Echo framework
 	e := echo.New()
 	healthHandler := handlers.HealthHandler{}
 	e.GET("/health", healthHandler.Handler())
 	e.GET("/api/version", handlers.VersionHandler(buildVersion))
 	e.POST("/syslog/drain/:token", syslogHandler.Handler())
+	e.POST("/ironio/drain/:token", ironIOHandler.Handler())
 
 	setupPprof(logger)
 	setupInterrupts(logger)


### PR DESCRIPTION
A new endpoint /ironio/dain/:token is available
This can be used to capture IronIO logs from your
IronIO project.