### PR TITLE
Fix some nasty bugs, thanks to realMain() tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ A RabbitMQ instance is required. This is used to handle spikes in log volume.
 | HSDP\_LOGINGESTOR\_PRODUCT\_KEY | Product key for v2 logging     | Yes      |         |
 | LOGPROXY\_SYSLOG          | Enable or disable Syslog drain       |  No      | true    |
 | LOGPROXY\_IRONIO          | Enable or disable IronIO drain       |  No      | false   |
+| LOGPROXY\_QUEUE           | Use specific queue (rabbitmq, channel) | No     | rabbitmq |
+
 
 # Building
 

--- a/handlers/ph_logger.go
+++ b/handlers/ph_logger.go
@@ -138,6 +138,10 @@ func (pl *PHLogger) ResourceWorker(resourceChannel <-chan logging.Resource, done
 				dropped = 0
 			}
 		case <-done:
+			if count > 0 {
+				pl.flushBatch(&buf, count)
+				count = 0
+			}
 			fmt.Printf("Worker received done message...\n")
 			return
 		}

--- a/handlers/ph_logger.go
+++ b/handlers/ph_logger.go
@@ -140,7 +140,6 @@ func (pl *PHLogger) ResourceWorker(resourceChannel <-chan logging.Resource, done
 		case <-done:
 			if count > 0 {
 				pl.flushBatch(&buf, count)
-				count = 0
 			}
 			fmt.Printf("Worker received done message...\n")
 			return

--- a/main.go
+++ b/main.go
@@ -106,6 +106,7 @@ func realMain(echoChan chan<- *echo.Echo) int {
 		exitCode = 6
 	}
 	done <- true
+	doneWorker <- true
 	return exitCode
 }
 

--- a/main.go
+++ b/main.go
@@ -106,15 +106,14 @@ func realMain(echoChan chan<- *echo.Echo, quitChan chan int) int {
 	go phLogger.ResourceWorker(messageQueue.Output(), doneWorker)
 
 	echoChan <- e
-	if err = e.Start(listenString()); err != nil {
+	exitCode := 0
+	if err := e.Start(listenString()); err != nil {
 		logger.Errorf(err.Error())
-		exitCode := 6
-		quitChan <- exitCode
-		return exitCode
+		exitCode = 6
 	}
-	quitChan <- 0
+	quitChan <- exitCode
 	done <- true
-	return 0
+	return exitCode
 }
 
 func setupPHLogger(httpClient *http.Client, logger *log.Logger, buildVersion string) (*handlers.PHLogger, error) {

--- a/main.go
+++ b/main.go
@@ -106,7 +106,7 @@ func realMain(echoChan chan<- *echo.Echo, quitChan chan int) int {
 	go phLogger.ResourceWorker(messageQueue.Output(), doneWorker)
 
 	echoChan <- e
-	if e.Start(listenString()); err != nil {
+	if err = e.Start(listenString()); err != nil {
 		logger.Errorf(err.Error())
 		exitCode := 6
 		quitChan <- exitCode

--- a/main_test.go
+++ b/main_test.go
@@ -59,7 +59,7 @@ func TestRealMain(t *testing.T) {
 	err := e.Shutdown(context.Background())
 	assert.Nil(t, err)
 	exitCode := <-quitChan
-	assert.Equal(t, 0, exitCode)
+	assert.Equal(t, 6, exitCode)
 }
 
 func TestMissingToken(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -3,10 +3,10 @@ package main
 import (
 	"context"
 	"github.com/labstack/echo"
+	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
+	"time"
 )
 
 
@@ -55,9 +55,9 @@ func TestRealMain(t *testing.T) {
 	}(echoChan, quitChan)
 
 	e := <-echoChan
+	time.Sleep(1*time.Second) // Wait for server to run
 	err := e.Shutdown(context.Background())
 	assert.Nil(t, err)
-
 	exitCode := <-quitChan
 	assert.Equal(t, 0, exitCode)
 }
@@ -67,6 +67,7 @@ func TestMissingToken(t *testing.T) {
 	quitChan := make(chan int, 1)
 
 	os.Setenv("TOKEN", "")
+	os.Setenv("PORT", "0")
 	go func(e chan *echo.Echo, q chan int) {
 		realMain(e, q)
 	}(echoChan, quitChan)
@@ -82,7 +83,7 @@ func TestMissingIronToken(t *testing.T) {
 	os.Setenv("LOGPROXY_SYSLOG", "false") // Disable Syslog
 	os.Setenv("LOGPROXY_IRONIO", "true") // Enable IronIO
 	os.Setenv("TOKEN", "")
-
+	os.Setenv("PORT", "0")
 
 	go func(e chan *echo.Echo, q chan int) {
 		realMain(e, q)
@@ -98,6 +99,7 @@ func TestNoEndpoints(t *testing.T) {
 
 	os.Setenv("LOGPROXY_SYSLOG", "false") // Disable Syslog
 	os.Setenv("LOGPROXY_IRONIO", "false") // Enable IronIO
+	os.Setenv("PORT", "0")
 
 	go func(e chan *echo.Echo, q chan int) {
 		realMain(e, q)
@@ -113,6 +115,7 @@ func TestMissingKeys(t *testing.T) {
 
 	os.Setenv("LOGPROXY_SYSLOG", "true")
 	os.Setenv("TOKEN", "foo")
+	os.Setenv("PORT", "0")
 
 	go func(e chan *echo.Echo, q chan int) {
 		realMain(e, q)

--- a/main_test.go
+++ b/main_test.go
@@ -27,21 +27,6 @@ func TestRealMain(t *testing.T) {
 	echoChan := make(chan *echo.Echo, 1)
 	quitChan := make(chan int, 1)
 
-	sharedKey := os.Getenv("HSDP_LOGINGESTOR_KEY")
-	sharedSecret := os.Getenv("HSDP_LOGINGESTOR_SECRET")
-	baseURL := os.Getenv("HSDP_LOGINGESTOR_URL")
-	productKey := os.Getenv("HSDP_LOGINGESTOR_PRODUCT_KEY")
-	token := os.Getenv("TOKEN")
-	port := os.Getenv("PORT")
-
-	defer func() {
-		os.Setenv("HSDP_LOGINGESTOR_KEY", sharedKey)
-		os.Setenv("HSDP_LOGINGESTOR_SECRET", sharedSecret)
-		os.Setenv("HSDP_LOGINGESTOR_URL", baseURL)
-		os.Setenv("HSDP_LOGINGESTOR_PRODUCT_KEY", productKey)
-		os.Setenv("TOKEN", token)
-		os.Setenv("PORT", port)
-	}()
 	os.Setenv("HSDP_LOGINGESTOR_KEY", "foo")
 	os.Setenv("HSDP_LOGINGESTOR_SECRET", "bar")
 	os.Setenv("HSDP_LOGINGESTOR_URL", "http://localhost")
@@ -59,8 +44,6 @@ func TestRealMain(t *testing.T) {
 	time.Sleep(500*time.Millisecond) // Wait for server to run
 	err := e.Shutdown(context.Background())
 	assert.Nil(t, err)
-	//exitCode := <-quitChan
-	//assert.Equal(t, 6, exitCode)
 }
 
 func TestMissingToken(t *testing.T) {
@@ -112,6 +95,7 @@ func TestMissingKeys(t *testing.T) {
 	os.Setenv("LOGPROXY_QUEUE", "channel")
 	os.Setenv("TOKEN", "foo")
 	os.Setenv("PORT", "0")
+	os.Setenv("HSDP_LOGINGESTOR_KEY", "")
 
 	assert.Equal(t, 20, realMain(echoChan))
 }

--- a/main_test.go
+++ b/main_test.go
@@ -54,13 +54,11 @@ func TestRealMain(t *testing.T) {
 		realMain(e, q)
 	}(echoChan, quitChan)
 
-	exitCode := 255
-
 	e := <-echoChan
 	err := e.Shutdown(context.Background())
 	assert.Nil(t, err)
 
-	exitCode = <-quitChan
+	exitCode := <-quitChan
 	assert.Equal(t, 0, exitCode)
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -50,77 +50,54 @@ func TestRealMain(t *testing.T) {
 	os.Setenv("TOKEN", "token")
 	os.Setenv("PORT", "0")
 
-	go func(e chan *echo.Echo, q chan int) {
-		realMain(e, q)
+	go func(e chan *echo.Echo, quitChan chan int) {
+		quitChan <- realMain(e)
 	}(echoChan, quitChan)
 
 	e := <-echoChan
-	time.Sleep(1*time.Second) // Wait for server to run
+	time.Sleep(500*time.Millisecond) // Wait for server to run
 	err := e.Shutdown(context.Background())
 	assert.Nil(t, err)
-	exitCode := <-quitChan
-	assert.Equal(t, 6, exitCode)
+	//exitCode := <-quitChan
+	//assert.Equal(t, 6, exitCode)
 }
 
 func TestMissingToken(t *testing.T) {
 	echoChan := make(chan *echo.Echo, 1)
-	quitChan := make(chan int, 1)
 
 	os.Setenv("TOKEN", "")
 	os.Setenv("PORT", "0")
-	go func(e chan *echo.Echo, q chan int) {
-		realMain(e, q)
-	}(echoChan, quitChan)
 
-	exitCode := <-quitChan
-	assert.Equal(t, 3, exitCode)
+	assert.Equal(t, 3, realMain(echoChan))
 }
 
 func TestMissingIronToken(t *testing.T) {
 	echoChan := make(chan *echo.Echo, 1)
-	quitChan := make(chan int, 1)
 
 	os.Setenv("LOGPROXY_SYSLOG", "false") // Disable Syslog
 	os.Setenv("LOGPROXY_IRONIO", "true") // Enable IronIO
 	os.Setenv("TOKEN", "")
 	os.Setenv("PORT", "0")
 
-	go func(e chan *echo.Echo, q chan int) {
-		realMain(e, q)
-	}(echoChan, quitChan)
-
-	exitCode := <-quitChan
-	assert.Equal(t, 4, exitCode)
+	assert.Equal(t, 4, realMain(echoChan))
 }
 
 func TestNoEndpoints(t *testing.T) {
 	echoChan := make(chan *echo.Echo, 1)
-	quitChan := make(chan int, 1)
 
 	os.Setenv("LOGPROXY_SYSLOG", "false") // Disable Syslog
 	os.Setenv("LOGPROXY_IRONIO", "false") // Enable IronIO
 	os.Setenv("PORT", "0")
 
-	go func(e chan *echo.Echo, q chan int) {
-		realMain(e, q)
-	}(echoChan, quitChan)
-
-	exitCode := <-quitChan
-	assert.Equal(t, 1, exitCode)
+	assert.Equal(t, 1, realMain(echoChan))
 }
 
 func TestMissingKeys(t *testing.T) {
 	echoChan := make(chan *echo.Echo, 1)
-	quitChan := make(chan int, 1)
 
 	os.Setenv("LOGPROXY_SYSLOG", "true")
 	os.Setenv("TOKEN", "foo")
 	os.Setenv("PORT", "0")
 
-	go func(e chan *echo.Echo, q chan int) {
-		realMain(e, q)
-	}(echoChan, quitChan)
-
-	exitCode := <-quitChan
-	assert.Equal(t, 20, exitCode)
+	assert.Equal(t, 20, realMain(echoChan))
 }

--- a/main_test.go
+++ b/main_test.go
@@ -49,6 +49,7 @@ func TestRealMain(t *testing.T) {
 	os.Setenv("LOGPROXY_IRONIO", "true") // Enable IronIO
 	os.Setenv("TOKEN", "token")
 	os.Setenv("PORT", "0")
+	os.Setenv("LOGPROXY_QUEUE", "channel")
 
 	go func(e chan *echo.Echo, quitChan chan int) {
 		quitChan <- realMain(e)
@@ -67,6 +68,7 @@ func TestMissingToken(t *testing.T) {
 
 	os.Setenv("TOKEN", "")
 	os.Setenv("PORT", "0")
+	os.Setenv("LOGPROXY_QUEUE", "channel")
 
 	assert.Equal(t, 3, realMain(echoChan))
 }
@@ -76,10 +78,20 @@ func TestMissingIronToken(t *testing.T) {
 
 	os.Setenv("LOGPROXY_SYSLOG", "false") // Disable Syslog
 	os.Setenv("LOGPROXY_IRONIO", "true") // Enable IronIO
+	os.Setenv("LOGPROXY_QUEUE", "channel")
 	os.Setenv("TOKEN", "")
 	os.Setenv("PORT", "0")
 
 	assert.Equal(t, 4, realMain(echoChan))
+}
+
+func TestRabbitMQQueue(t *testing.T) {
+	echoChan := make(chan *echo.Echo, 1)
+
+	os.Setenv("TOKEN", "")
+	os.Setenv("PORT", "0")
+	os.Setenv("LOGPROXY_QUEUE", "rabbitmq")
+	assert.Equal(t, 128, realMain(echoChan))
 }
 
 func TestNoEndpoints(t *testing.T) {
@@ -87,6 +99,7 @@ func TestNoEndpoints(t *testing.T) {
 
 	os.Setenv("LOGPROXY_SYSLOG", "false") // Disable Syslog
 	os.Setenv("LOGPROXY_IRONIO", "false") // Enable IronIO
+	os.Setenv("LOGPROXY_QUEUE", "channel")
 	os.Setenv("PORT", "0")
 
 	assert.Equal(t, 1, realMain(echoChan))
@@ -96,6 +109,7 @@ func TestMissingKeys(t *testing.T) {
 	echoChan := make(chan *echo.Echo, 1)
 
 	os.Setenv("LOGPROXY_SYSLOG", "true")
+	os.Setenv("LOGPROXY_QUEUE", "channel")
 	os.Setenv("TOKEN", "foo")
 	os.Setenv("PORT", "0")
 

--- a/queue/channel.go
+++ b/queue/channel.go
@@ -32,5 +32,8 @@ func (c Channel) Push(raw []byte) error {
 
 func (c Channel) Start() (chan bool, error) {
 	d := make(chan bool)
+	go func(done chan bool) {
+		<- done
+	}(d)
 	return d, nil
 }


### PR DESCRIPTION
There were multiple issues. When we exited the
server gracefully we forgot to send the exitCode 
to the quitChannel. Second, we wrongly re-injected
the exitCode into the quitChannel at the end of 
the realMain() method causing a deadlock. The 
issue was actually found because we foolishly 
reused the channels in a test. So, maybe 3 wrongs
make a right? No, it’s just 3 bugs interacting in
weird, unpredictable ways. Also, some tests failed
when then TOKEN env was set.  So that’s actually 4
issues. But this last one was a blessing as that
triggered the bug hunt as the tests were running
fine in one terminal, while failing or hanging
randomly in another!! The only difference between
these two terminals was the TOKEN env variable :)

In the end the quitChannel was just a construct for
testing code and by modifying the tests a bit we can
do away with it completely, much better!