### PR TITLE
Add 🚚  option support

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/philips-software/go-hsdp-api/logging"
+
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 )
@@ -124,4 +126,11 @@ func TestMissingKeys(t *testing.T) {
 	os.Setenv("LOGPROXY_DELIVERY", "hsdp")
 
 	assert.Equal(t, 20, realMain(echoChan))
+}
+
+func TestNoneStorer(t *testing.T) {
+	noneStorer := &noneStorer{}
+	res, err := noneStorer.StoreResources([]logging.Resource{logging.Resource{}}, 1)
+	assert.Nil(t, err)
+	assert.NotNil(t, res)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -35,6 +35,26 @@ func TestRealMain(t *testing.T) {
 	os.Setenv("TOKEN", "token")
 	os.Setenv("PORT", "0")
 	os.Setenv("LOGPROXY_QUEUE", "channel")
+	os.Setenv("LOGPROXY_DELIVERY", "hsdp")
+
+	go func(e chan *echo.Echo, quitChan chan int) {
+		quitChan <- realMain(e)
+	}(echoChan, quitChan)
+
+	e := <-echoChan
+	time.Sleep(500 * time.Millisecond) // Wait for server to run
+	err := e.Shutdown(context.Background())
+	assert.Nil(t, err)
+}
+
+func TestRealMainWithNoneDelivery(t *testing.T) {
+	echoChan := make(chan *echo.Echo, 1)
+	quitChan := make(chan int, 1)
+
+	os.Setenv("TOKEN", "token")
+	os.Setenv("PORT", "0")
+	os.Setenv("LOGPROXY_QUEUE", "channel")
+	os.Setenv("LOGPROXY_DELIVERY", "none")
 
 	go func(e chan *echo.Echo, quitChan chan int) {
 		quitChan <- realMain(e)
@@ -52,6 +72,7 @@ func TestMissingToken(t *testing.T) {
 	os.Setenv("TOKEN", "")
 	os.Setenv("PORT", "0")
 	os.Setenv("LOGPROXY_QUEUE", "channel")
+	os.Setenv("LOGPROXY_DELIVERY", "hsdp")
 
 	assert.Equal(t, 3, realMain(echoChan))
 }
@@ -64,6 +85,7 @@ func TestMissingIronToken(t *testing.T) {
 	os.Setenv("LOGPROXY_QUEUE", "channel")
 	os.Setenv("TOKEN", "")
 	os.Setenv("PORT", "0")
+	os.Setenv("LOGPROXY_DELIVERY", "hsdp")
 
 	assert.Equal(t, 4, realMain(echoChan))
 }
@@ -74,6 +96,8 @@ func TestRabbitMQQueue(t *testing.T) {
 	os.Setenv("TOKEN", "")
 	os.Setenv("PORT", "0")
 	os.Setenv("LOGPROXY_QUEUE", "rabbitmq")
+	os.Setenv("LOGPROXY_DELIVERY", "hsdp")
+
 	assert.Equal(t, 128, realMain(echoChan))
 }
 
@@ -84,6 +108,7 @@ func TestNoEndpoints(t *testing.T) {
 	os.Setenv("LOGPROXY_IRONIO", "false") // Enable IronIO
 	os.Setenv("LOGPROXY_QUEUE", "channel")
 	os.Setenv("PORT", "0")
+	os.Setenv("LOGPROXY_DELIVERY", "hsdp")
 
 	assert.Equal(t, 1, realMain(echoChan))
 }
@@ -96,6 +121,7 @@ func TestMissingKeys(t *testing.T) {
 	os.Setenv("TOKEN", "foo")
 	os.Setenv("PORT", "0")
 	os.Setenv("HSDP_LOGINGESTOR_KEY", "")
+	os.Setenv("LOGPROXY_DELIVERY", "hsdp")
 
 	assert.Equal(t, 20, realMain(echoChan))
 }


### PR DESCRIPTION
Set LOGPROXY_DELIVERY:

- “none” - Don’t deliver any logs, only processing
- “hsdp” - Deliver to HSDP Logging (default)