### PR TITLE
Bugfix: unpack batch with failed messages #279

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/loafoe/go-rabbitmq v0.5.0
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/openzipkin/zipkin-go v0.4.1
-	github.com/philips-software/go-hsdp-api v0.75.0
+	github.com/philips-software/go-hsdp-api v0.75.6
 	github.com/prometheus/client_golang v1.14.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/viper v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -831,8 +831,8 @@ github.com/pelletier/go-toml/v2 v2.0.5 h1:ipoSadvV8oGUjnUbMub59IDPPwfxF694nG/jwb
 github.com/pelletier/go-toml/v2 v2.0.5/go.mod h1:OMHamSCAODeSsVrwwvcJOaoN0LIUIaFVNZzmWyNfXas=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/philhofer/fwd v1.0.0/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG3ZVNU=
-github.com/philips-software/go-hsdp-api v0.75.0 h1:AjYazGCntd6jH2xtGhxqqgy49bjvvAC+4bljvFVDE8k=
-github.com/philips-software/go-hsdp-api v0.75.0/go.mod h1:rd6uphXchFcYW2ehT5xWGobAZrIod7qSOLZUqWh61y4=
+github.com/philips-software/go-hsdp-api v0.75.6 h1:ic04DulkTUgG3VQ0n2UdVy1cD8mjWgC3nVI//H4+Km4=
+github.com/philips-software/go-hsdp-api v0.75.6/go.mod h1:WLknlRw2GiSmtDufXcy28YHOcbQXn3RfB9RrT5cimxQ=
 github.com/philips-software/go-hsdp-signer v1.4.0 h1:yg7UILhmI4xJhr/tQiAiQwJL0EZFvLuMqpH2GZ9ygY4=
 github.com/philips-software/go-hsdp-signer v1.4.0/go.mod h1:/QehZ/+Aks2t1TFpjhF/7ZSB8PJIIJHzLc03rOqwLw0=
 github.com/pierrec/lz4 v2.6.1+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=

--- a/queue/channel_test.go
+++ b/queue/channel_test.go
@@ -50,9 +50,9 @@ func (n *nilStorer) StoreResources(_ []logging.Resource, count int) (*logging.St
 			Response: &http.Response{
 				StatusCode: http.StatusBadRequest,
 			},
-			Failed: map[int]logging.Resource{
-				10: {},
-				20: {},
+			Failed: []logging.Resource{
+				{},
+				{},
 			},
 		}, logging.ErrBatchErrors
 	}

--- a/queue/deliverer_test.go
+++ b/queue/deliverer_test.go
@@ -253,7 +253,7 @@ func TestDroppedMessages(t *testing.T) {
 	_, _ = io.Copy(&buf, r)
 
 	assert.Regexp(t, regexp.MustCompile("batch flushing 23 messages"), buf.String())
-	assert.Regexp(t, regexp.MustCompile("Found 2 errors. Resending 21"), buf.String())
+	assert.Regexp(t, regexp.MustCompile("resending 4"), buf.String())
 }
 
 func TestEncodeString(t *testing.T) {


### PR DESCRIPTION
A batch with failed messages will now be unpacked and each message will be retransmitted individually. In case of failure the message will be delivered to the dead-letter queue (currently a black hole)