### PR TITLE
Fix: Remove deprecated grpc DialContext

### DIFF
--- a/shared/proto/resource.pb_test.go
+++ b/shared/proto/resource.pb_test.go
@@ -143,7 +143,7 @@ func TestProtoFilterRequest(t *testing.T) {
 
 func TestFilter(t *testing.T) {
 	ctx := context.Background()
-	conn, err := grpc.DialContext(ctx, "bufnet", grpc.WithContextDialer(bufDialer), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient("passthrough://bufnet", grpc.WithContextDialer(bufDialer), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatalf("Failed to dial bufnet: %v", err)
 	}


### PR DESCRIPTION
Using the grpc NewClient resolves the following issue:
![image](https://github.com/user-attachments/assets/3246984c-2cf1-488f-a606-086a89b3cc94)
https://github.com/philips-software/logproxy/actions/runs/12041976555/job/33574829747

Test is passing:
![image](https://github.com/user-attachments/assets/42ef142e-33a3-4fdd-b13b-629b8463c238)

No Issue more when running lint:
